### PR TITLE
Fix Apache Eagle link as eagle.incubator.apache.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         <div class="content wow fadeIn">
           <h2 class="major">Featured Project  - <a href="http://goeagle.io/" target="_blank">Apache Eagle</a></h2>
           <p>Apache Eagle is an Open Source Monitoring solution to instantly identify access to sensitive data, recognize attacks, malicious activities in Hadoop and take actions in real time.</p>
-          <a href="http://goeagle.io/" class="special" target="_blank">Learn more</a> </div>
+          <a href="http://eagle.incubator.apache.org/" class="special" target="_blank">Learn more</a> </div>
       </div>
     </section>
     


### PR DESCRIPTION
http://goeagle.io is out of maintenance, so update the link of apache eagle as http://eagle.incubator.apache.org