### PR TITLE
Broken/inconsistent links, rel=noopener security and other various defects.

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -30,14 +30,14 @@
         <div class="col-md-5 col-sm-5 col-xs-5">
           <h1>
             <a href="index.html">
-              <img class="logo" src="images/ebay_logo.png" alt="eBay"> Open Source</a>
+              <img class="logo" src="images/logo.svg" alt="eBay"> Open Source</a>
           </h1>
         </div>
     
         <div class="col-md-7 col-sm-6 col-xs-7">
           <ul class="contacts pull-right">
             <li>
-              <a href="mailto:open@ebay.com" class="fa fa-envelope icontop"></a>
+              <a href="mailto:open@ebay.com" class="icon fa fa-envelope icontop"></a>
             </li>
           </ul>
         </div>
@@ -134,7 +134,7 @@
         <div class="inner">
           <div class="row">
             <div class="col-md-12" style="text-align:center">
-              <span class="copyright">&copy; Copyright 2016-2018 eBay Inc. All rights reserved.</span>
+              <span class="copyright">&copy; Copyright 2016-2019 eBay Inc. All rights reserved.</span>
               Code of Conduct |
               <a href="https://github.com/eBay/" target="_blank">Contribute</a>
             </div>

--- a/index.html
+++ b/index.html
@@ -145,20 +145,13 @@
                       that came from us."</h3>
                     <p class="author">Steve Fisher, SVP and CTO</p>
                   </li>
-
-                  <li>
-                    <div class="avatar"><img src="images/rj.jpg" alt="Avatar"></div>
-                    <h3 class="quotes">"Not only do we encourage use and contributions to open source code at eBay, we also embrace the open source development model. We have many programs in place, like Hack Week and SkunkWorks, to drive innovation
-                      through active collaboration and distributed code contributions across many different teams."</h3>
-                    <p class="author">RJ Pittman, SVP and CPO</p>
-                  </li>
                 </ul>
               </div>
             </div>
           </div>
 
           <ul class="" style="text-align:center; margin-top:100px;">
-            <li><a href="https://careers.ebayinc.com/join-our-team/start-your-search/" class="button" target="_blank" rel="noopener">Join Our Community</a></li>
+            <li><a href="https://careers.ebayinc.com/" class="button" target="_blank" rel="noopener">Join Our Community</a></li>
           </ul>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
     <header id="topnav">
       <div class="row">
         <div class="col-md-5 col-sm-5 col-xs-5">
-          <h1><a href="index.html"><img class="logo" src="images/ebay_logo.png" alt="eBay"> Open Source</a></h1>
+          <h1><a href="index.html"><img class="logo" src="images/logo.svg" alt="eBay"> Open Source</a></h1>
         </div>
 
         <div class="col-md-7 col-sm-6 col-xs-7">
           <ul class="contacts pull-right">
-            <li><a href="mailto:open@ebay.com" class="fa fa-envelope icontop"></a></li>
+            <li><a href="mailto:open@ebay.com" class="icon fa fa-envelope icontop"></a></li>
           </ul>
         </div>
       </div>
@@ -41,12 +41,12 @@
 
     <section id="banner">
       <div class="inner">
-        <div class="logo wow fadeInDown"><img src="images/ebay_logo.png" alt="eBay"></div>
+        <div class="logo wow fadeInDown"><img src="images/logo.svg" alt="eBay"></div>
         <h2 class="wow fadeIn" data-wow-duration="1.5s" data-wow-delay="0.7s">Open Source</h2>
         <p class="wow fadeIn" data-wow-duration="1.5s" data-wow-delay="1.4s">Welcome to the home of eBay’s open source projects. Many of the projects you will find here started off as internal eBay projects, or as personal projects of our employees. We hope that you will be able to incorporate these projects into
           your own work, and we strongly encourage you to participate in our developer community.</p>
         <ul class="contacts wow fadeInDown" data-wow-duration="1.5s" data-wow-delay="2s">
-          <li><a href="mailto:open@ebay.com" class="fa fa-envelope"></a></li>
+          <li><a href="mailto:open@ebay.com" class="icon fa fa-envelope"></a></li>
         </ul>
       </div>
     </section>
@@ -54,31 +54,31 @@
     <section id="wrapper">
       <section id="one" class="wrapper spotlight style1">
         <div class="inner">
-          <a href="https://github.com/eBay/fabio" class="image wow fadeIn" target="_blank"><img src="images/fabio.png" alt="" /></a>
+          <a href="https://github.com/eBay/fabio" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/fabio.png" alt="" /></a>
           <div class="content wow fadeIn">
-            <h2 class="major">Featured Project - <a href="" target="_blank"> Fabio</a></h2>
+            <h2 class="major">Featured Project - <a href="https://github.com/eBay/fabio" target="_blank" rel="noopener"> Fabio</a></h2>
             <p>Fabio is a fast, modern, zero-conf load balancing HTTP(S) router for deploying microservices managed by consul.</p>
-            <a href="https://github.com/eBay/fabio" class="special" target="_blank">Learn more</a>
+            <a href="https://github.com/eBay/fabio" class="special" target="_blank" rel="noopener">Learn more</a>
           </div>
         </div>
       </section>
 
       <section id="two" class="wrapper alt spotlight style2">
-        <div class="inner"> <a href="http://kylin.apache.org/" target="_blank" class="image wow fadeIn"><img src="images/kylin.png" alt="" /></a>
+        <div class="inner"> <a href="http://kylin.apache.org/" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/kylin.png" alt="" /></a>
           <div class="content wow fadeIn">
-            <h2 class="major">Featured Project - <a href="http://kylin.incubator.apache.org/" target="_blank"> Apache Kylin</a></h2>
+            <h2 class="major">Featured Project - <a href="http://kylin.apache.org/" target="_blank" rel="noopener"> Apache Kylin</a></h2>
             <p>Apache Kylin is an open source Distributed Analytics Engine designed to provide SQL interface and multi-dimensional analysis (OLAP) on Hadoop supporting extremely large datasets.</p>
-            <a href="http://kylin.apache.org/" class="special wow fadeIn" target="_blank">Learn more</a>
+            <a href="http://kylin.apache.org/" class="special wow fadeIn" target="_blank" rel="noopener">Learn more</a>
           </div>
         </div>
       </section>
 
       <section id="three" class="wrapper  spotlight style3">
-        <div class="inner"> <a href="#" class="image wow fadeIn"><img src="images/eagle.png" alt="" /></a>
+        <div class="inner"> <a href="http://eagle.apache.org/" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/eagle.png" alt="" /></a>
           <div class="content wow fadeIn">
-            <h2 class="major">Featured Project - <a href="http://eagle.incubator.apache.org/" target="_blank">Apache Eagle</a></h2>
+            <h2 class="major">Featured Project - <a href="http://eagle.apache.org/" target="_blank" rel="noopener">Apache Eagle</a></h2>
             <p>Apache Eagle is an Open Source Monitoring solution to instantly identify access to sensitive data, recognize attacks, malicious activities in Hadoop and take actions in real time.</p>
-            <a href="http://eagle.incubator.apache.org/" class="special" target="_blank">Learn more</a>
+            <a href="http://eagle.apache.org/" class="special" target="_blank" rel="noopener">Learn more</a>
           </div>
         </div>
       </section>
@@ -89,44 +89,38 @@
           <p class="wow fadeIn">Some additional projects are found below. You can find a full list of our projects on www.github.com/ebay. Open source is supported by the very top levels of the company, so expect to see many more projects from eBay!</p>
           <section class="features row">
             <article class="col-md-6">
-              <a href="http://gopulsar.io/" class="image wow fadeIn" target="_blank"><img src="images/pulsar.jpg" alt="" /></a>
+              <a href="http://gopulsar.io/" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/pulsar.jpg" alt="" /></a>
               <h3 class="major wow fadeIn">Pulsar</h3>
               <p>Pulsar is an open-source, real-time analytics platform that includes stream processing, metrics store, and reporting frameworks. Pulsar can be used to collect, process user and business events in real time, provide key insights
                   using custom dashboards, and enable systems to react to user activities within seconds.</p>
-              <a href="http://gopulsar.io/" class="special" target="_blank">Learn more</a>
+              <a href="http://gopulsar.io/" class="special" target="_blank" rel="noopener">Learn more</a>
             </article>
             
             <article class="col-md-6">
-              <a href="https://github.com/eBay/parallec" class="image wow fadeIn" target="_blank"><img src="images/parallec.jpg" alt="" /></a>
+              <a href="https://github.com/eBay/parallec" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/parallec.jpg" alt="" /></a>
               <h3 class="major">Parallec</h3>
               <p>Parallec is a fast parallel async HTTP(S)/SSH/TCP/Ping client java library based on Akka. Scalably aggregate and handle API responses anyway and send it anywhere by writing 20 lines of code. </p>
-              <a href="https://github.com/eBay/parallec" class="special" target="_blank">Learn more</a>
+              <a href="https://github.com/eBay/parallec" class="special" target="_blank" rel="noopener">Learn more</a>
             </article>
             
             <article class="col-md-6">
-              <a href="https://github.com/eBay/NMessenger" class="image wow fadeIn " target="_blank"><img src="images/N.jpg" alt="" /></a>
+              <a href="https://github.com/eBay/NMessenger" class="image wow fadeIn " target="_blank" rel="noopener"><img src="images/N.jpg" alt="" /></a>
               <h3 class="major">NMessenger</h3>
               <p>NMessenger is a fast, lightweight messenger component built on AsyncDisplaykit and written in Swift. Developers can inherently achieve 60FPS scrolling and smooth transitions with rich content components.</p>
-              <a href="https://github.com/eBay/NMessenger" class="special" target="_blank">Learn more</a>
+              <a href="https://github.com/eBay/NMessenger" class="special" target="_blank" rel="noopener">Learn more</a>
             </article>
             
             <article class="col-md-6">
-              <a href="https://github.com/eBay/UAF" class="image wow fadeIn" target="_blank"><img src="images/UAF.jpg" alt="" /></a>
+              <a href="https://github.com/eBay/UAF" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/UAF.jpg" alt="" /></a>
               <h3 class="major">UAF</h3>
               <p>Universal Authentication Framework. The main goal is the passwordless authentication experience </p>
-              <a href="https://github.com/eBay/UAF" class="special" target="_blank">Learn more</a>
+              <a href="https://github.com/eBay/UAF" class="special" target="_blank" rel="noopener">Learn more</a>
             </article>
 
-            <article class="col-md-6"> <a href="https://github.com/eBay/GZinga" class="image wow fadeIn" target="_blank"><img src="images/gzynga.jpg" alt="" /></a>
+            <article class="col-md-6"> <a href="https://github.com/eBay/GZinga" class="image wow fadeIn" target="_blank" rel="noopener"><img src="images/gzynga.jpg" alt="" /></a>
               <h3 class="major">Gzynga</h3>
               <p>Seekable and Splittable GZip. This project is aim to provide Seekable (random search within gzip file) and Splittable (can divide gzip file into multiple chunks) capability for gzip compressed file.</p>
-              <a href="https://github.com/eBay/GZinga" class="special" target="_blank">Learn more</a>
-            </article>
-
-            <article class="col-md-6"> <a href="#" class="image wow fadeIn" target="_blank"><img src="images/sherlock.jpg" alt="" /></a>
-              <h3 class="major">Sherlock</h3>
-              <p>Sherlock provides real time monitoring of our infrastructure, services and applications.</p>
-              <a href="#" class="special" target="_blank">Learn more</a>
+              <a href="https://github.com/eBay/GZinga" class="special" target="_blank" rel="noopener">Learn more</a>
             </article>
           </section>
         </div>
@@ -164,7 +158,7 @@
           </div>
 
           <ul class="" style="text-align:center; margin-top:100px;">
-            <li><a href="https://careers.ebayinc.com/join-our-team/start-your-search/" class="button" target="_blank">Join Our Community</a></li>
+            <li><a href="https://careers.ebayinc.com/join-our-team/start-your-search/" class="button" target="_blank" rel="noopener">Join Our Community</a></li>
           </ul>
         </div>
       </section>
@@ -173,19 +167,20 @@
         <div class="inner">
           <div class="row">
             <div class="col-md-12" style="text-align:center">
-              <span class="copyright">&copy; Copyright 2016-2018 eBay Inc. All rights reserved.</span>
+              <span class="copyright">&copy; Copyright 2016-2019 eBay Inc. All rights reserved.</span>
               <a href="codeofconduct.html">Code of Conduct</a> | 
-              <a href="https://github.com/eBay/" target="_blank">Contribute</a></div>
+              <a href="https://github.com/eBay/" target="_blank" rel="noopener">Contribute</a></div>
           </div>
         </div>
       </section>
-    </div>
+    </section>
+  </div>
 
-    <script src="assets/js/jquery.min.js"></script>
-    <script src="assets/js/main.js"></script>
-    <script src="assets/js/wow.min.js"></script>
-    <script src="assets/js/jquery.flexslider-min.js"></script>
-    <script>
+  <script src="assets/js/jquery.min.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script src="assets/js/wow.min.js"></script>
+  <script src="assets/js/jquery.flexslider-min.js"></script>
+  <script>
       var wow = new WOW({
         boxClass: 'wow',
         animateClass: 'animated',


### PR DESCRIPTION
Full change log:

1. Eagle logo is wrapped in a link but goes nowhere, but the "learn more" link is pointing to http://eagle.incubator.apache.org/
2. The link for Sherlock (very bottom) goes nowhere and should probably be removed entirely since that project isn't open sourced yet.
3. Links to external domains should include `rel="noopener"` ([more info](https://developers.google.com/web/tools/lighthouse/audits/noopener)).
4. Several other links are outdated or inconsistent (e.g. including `.incubator` in the domain under `apache.org` in some instances).
5. Fixed unclosed `</section>` tag.
6. Email icon has underline when not being `:hover`'ed, except this is/was oddly only visible >=1681px 
 breakpoint. This appears to be an artifact of the `.icon` class having been removed over time.
7. Our eBay logo is no longer supposed to include "tm" in it. While adjusting this, I also ensured we're using SVG (IE9+ support anyway) so it's less blurry, especially on higher res devices. Also ensures it will look perfect regardless of scale (as it is reused anyway).
8. Updating copyright to extend to 2019.

Originally this started as issue #19 but I decided to move to a PR so I could roll up the changes in code, since they were all fairly quick. 